### PR TITLE
Add permissions on individual journal pages

### DIFF
--- a/styles/ownership_viewer.css
+++ b/styles/ownership_viewer.css
@@ -30,7 +30,19 @@ div.ownership-viewer > a {
 
 
 
+.ownership-viewer-all.ownership-viewer-inherit {
+    /* Move the center point up on the triangle*/
+    border-top-width: 5px;
+    border-bottom-width: 9px;
+}
+
+.ownership-viewer-inherit {
+    /* Create a downwards triangle */
+    clip-path: polygon(50% 100%, 0 0, 100% 0);
+}
+
 .ownership-viewer-limited {
+    /* Create a diamond */
     -webkit-transform-origin:50% 50%;
     -ms-transform-origin:50% 50%;
     transform-origin:50% 50%;
@@ -41,9 +53,11 @@ div.ownership-viewer > a {
 }
 
 .ownership-viewer-observer {
+    /* Create a square */
     border-radius: 0;
 }
 
 .ownership-viewer-owner {
+    /* Create a circle */
     border-radius: 50%;
 }


### PR DESCRIPTION
This PR resolves #47, by doing two things:

1. Add the permission viewer to pages within journals
2. Add support for the "Inherit" permission level

## Add the permission viewer to pages within journals

Adding this required minor changes, mostly around jQuery selection strings and hooking onto "renderJournalSheet".

In the journal popup, the current page's heading gets re-rendered after the journal itself, so registering the click events needs to happen after the current page is rendered rather than when the journal is rendered.

## Add support for the "Inherit" permission level

Along with the journal update, V10 added a new permission level called "inherit". This permission level means that pages "inherit" the permissions of the journal they are within. While the permission level is currently only applicable to journals & pages, it wouldn't be surprising if Foundry expanded this permission level into other areas.

Since there is a new permission level, we need an icon for it. I picked a downwards facing triangle for two reasons:

1. It fits with the current style, where each permission level has it's own shape
2. A downwards triangle _feels_ symbolically correct for inheriting something above it

The screenshot below shows the pages in a journal with the respective permissions: Inherit, None, Limited, Observer, Owner

<img width="1000" alt="Screenshot 2023-02-09 at 2 44 08 PM" src="https://user-images.githubusercontent.com/44244481/217922751-b20ccda3-b86e-4024-80a4-7a94ef4999e1.png">
